### PR TITLE
total training iters may equal to warmup_iters

### DIFF
--- a/ch05/05_bonus_hparam_tuning/hparam_search.py
+++ b/ch05/05_bonus_hparam_tuning/hparam_search.py
@@ -82,7 +82,7 @@ def train_model(model, train_loader, val_loader, optimizer, device,
             global_step += 1
 
             # Warmup: adjust learning rate linearly
-            if global_step < warmup_iters:
+            if global_step <= warmup_iters:
                 lr = initial_lr + global_step * lr_increment
             # Cosine annealing phase
             else:


### PR DESCRIPTION
total_training_iters=20, warmup_iters=20= len(train_loader) 4 multiply n_epochs 5, then ZeroDivisionError occurred.
```shell
Traceback (most recent call last):                                                                                                     
  File "LLMs-from-scratch/ch05/05_bonus_hparam_tuning/hparam_search.py", line 188, in <module>                    
    train_loss, val_loss = train_model(                                                                                                
                           ^^^^^^^^^^^^                                                                                                
  File "/mnt/raid1/docker/ai/LLMs-from-scratch/ch05/05_bonus_hparam_tuning/hparam_search.py", line 89, in train_model                  
    progress = (global_step - warmup_iters) / (total_training_iters - warmup_iters)                                                    
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    
ZeroDivisionError: division by zero  
```